### PR TITLE
TextSynth & OpenAI Integrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+TEXTSYNTH_API_KEY=add_your_key_here
+OPENAI_API_KEY=add_your_key_here

--- a/app.py
+++ b/app.py
@@ -1,10 +1,12 @@
 """Streamlit entry point for the Touch 2025 RAD demo."""
 
 import streamlit as st
+from touche_rad.ai import TextSynthClient
 from touche_rad.streamlit import Chat
 
 st.title("Touche 2025 RAD Demo")
 st.markdown("""
 This a demo of the Retrieval Augmented Dabate (RAD) system build by DS@GT CLEF Touche.
 """)
-Chat().render()
+ai_client = TextSynthClient()
+Chat(chat_client=ai_client).render()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   app:
     build: .
+    env_file:
+      - .env
     volumes:
       - .:/app
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   app:
     build: .
-    env_file:
-      - .env
     volumes:
       - .:/app
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,6 @@ services:
     ports:
       - "8501:8501"
     command: streamlit run app.py
+    environment:
+      - TEXTSYNTH_API_KEY
+      - OPENAI_API_KEY

--- a/touche_rad/ai/__init__.py
+++ b/touche_rad/ai/__init__.py
@@ -1,0 +1,13 @@
+from .base import Message, ChatClient, ChatModelEnum
+from .openai import OpenAIClient, OpenAIModel
+from .textsynth import TextSynthClient, TextSynthEngine
+
+__all__ = [
+    "Message",
+    "ChatClient",
+    "ChatModelEnum",
+    "OpenAIClient",
+    "OpenAIModel",
+    "TextSynthClient",
+    "TextSynthEngine",
+]

--- a/touche_rad/ai/__init__.py
+++ b/touche_rad/ai/__init__.py
@@ -1,11 +1,9 @@
-from .base import Message, ChatClient, ChatModelEnum
+from .base import Message
 from .openai import OpenAIClient, OpenAIModel
 from .textsynth import TextSynthClient, TextSynthEngine
 
 __all__ = [
     "Message",
-    "ChatClient",
-    "ChatModelEnum",
     "OpenAIClient",
     "OpenAIModel",
     "TextSynthClient",

--- a/touche_rad/ai/__init__.py
+++ b/touche_rad/ai/__init__.py
@@ -1,9 +1,10 @@
-from .base import Message
+from .base import Message, ChatClient
 from .openai import OpenAIClient, OpenAIModel
 from .textsynth import TextSynthClient, TextSynthEngine
 
 __all__ = [
     "Message",
+    "ChatClient",
     "OpenAIClient",
     "OpenAIModel",
     "TextSynthClient",

--- a/touche_rad/ai/base.py
+++ b/touche_rad/ai/base.py
@@ -1,0 +1,51 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import List
+
+
+class ChatModelEnum(str, Enum):
+    """
+    Base API chat model enum for listing available models and providing a
+    default model
+    """
+
+    @classmethod
+    @abstractmethod
+    def chat_models(cls) -> List["ChatModelEnum"]:
+        """
+        Return the list of models that are supported for chat from specified client
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def default_model(cls) -> "ChatModelEnum":
+        """
+        Return the defined default model
+        """
+        pass
+
+
+@dataclass
+class Message:
+    """
+    Chat Message dataclass
+    """
+
+    role: str
+    content: str
+
+
+class ChatClient(ABC):
+    """
+    Base class to make interchangeable chat completion
+    providers, similarly to how OpenAI provides an SDK of its own
+    """
+
+    @abstractmethod
+    def chat(self, messages: List[Message]) -> str:
+        """
+        Send chat messages and return the response
+        """
+        pass

--- a/touche_rad/ai/openai.py
+++ b/touche_rad/ai/openai.py
@@ -1,0 +1,74 @@
+import os
+from typing import List
+from .base import ChatModelEnum, ChatClient, Message
+from openai import OpenAI
+
+
+class OpenAIModel(ChatModelEnum):
+    """
+    Available chat models provided by the OpenAI Chat API
+    """
+
+    GPT4_O = "gpt-4o"
+    GPT4_O_LATEST = "chatgpt-4o-latest"
+    GPT4_O_MINI = "gpt-4o-mini"
+
+    # TODO: support reasoning models?
+    # O1 = "o1"
+    # O1_MINI = "o1-mini"
+    # O3_MINI = "o3-mini"
+    # O1_PREVIEW = "o1-preview"
+
+    @classmethod
+    def default_model(cls) -> "OpenAIModel":
+        return cls.GPT4_O
+
+    @classmethod
+    def chat_models(cls) -> List["OpenAIModel"]:
+        return [
+            cls.GPT4_O,
+            cls.GPT4_O_LATEST,
+            cls.GPT4_O_MINI,
+            # cls.O1,
+            # cls.O1_MINI,
+            # cls.O3_MINI,
+            # cls.O1_PREVIEW,
+        ]
+
+    # @classmethod
+    # def reasoning_models(cls) -> List["OpenAIModel"]:
+    #     return [
+    #         cls.O1,
+    #         cls.O1_MINI,
+    #         cls.O3_MINI,
+    #         cls.O1_PREVIEW
+    #     ]
+
+
+class OpenAIClient(ChatClient):
+    """
+    OpenAIChatClient - can also support other providers that enable the leveraging
+    of the OpenAI SDK with their API
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = os.environ.get("OPENAI_API_KEY"),
+        url: str | None = None,
+        model: OpenAIModel = OpenAIModel.default_model(),
+    ):
+        self._client = (
+            OpenAI(api_key=api_key, base_url=url) if url else OpenAI(api_key=api_key)
+        )
+        self.model = model
+
+    @property
+    def client(self):
+        return self._client
+
+    def chat(self, messages: List[Message]) -> str:
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": msg.role, "content": msg.content} for msg in messages],
+        )
+        return response.choices[0].message.content

--- a/touche_rad/ai/textsynth.py
+++ b/touche_rad/ai/textsynth.py
@@ -1,0 +1,74 @@
+import os
+from typing import List
+
+import requests
+from .base import ChatModelEnum, ChatClient, Message
+
+
+class TextSynthEngine(ChatModelEnum):
+    """
+    Available chat engines provided by the TextSynth API
+    https://textsynth.com/documentation.html#engines
+    """
+
+    MISTRAL_7B = "mistral_7B"
+    LLAMA3_8B = "llama3_8B"
+    LLAMA3_1_8B_INSTRUCT = "llama3.1_8B_instruct"
+    MIXTRAL_47B_INSTRUCT = "mixtral_47B_instruct"
+    LLAMA3_3_70B_INSTRUCT = "llama3.3_70B_instruct"
+    GPTJ_6B = "gptj_6B"
+
+    @classmethod
+    def default_model(cls) -> "TextSynthEngine":
+        return cls.LLAMA3_3_70B_INSTRUCT
+
+    @classmethod
+    def chat_models(cls) -> List["TextSynthEngine"]:
+        return [
+            cls.MISTRAL_7B,
+            cls.LLAMA3_8B,
+            cls.LLAMA3_1_8B_INSTRUCT,
+            cls.MIXTRAL_47B_INSTRUCT,
+            cls.LLAMA3_3_70B_INSTRUCT,
+            cls.GPTJ_6B,
+        ]
+
+
+class TextSynthClient(ChatClient):
+    """
+    TextSynth ChatClient
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = os.environ.get("TEXTSYNTH_API_KEY"),
+        engine_id: TextSynthEngine = TextSynthEngine.default_model(),
+        system_prompt: str | None = None,
+    ):
+        self.api_key = api_key
+        if not self.api_key:
+            raise ValueError("TEXTSYNTH_API_KEY environment variable not set")
+
+        if engine_id not in TextSynthEngine.chat_models():
+            raise ValueError(
+                f"Invalid engine_id for chat. Must be one of: {', '.join(e.value for e in TextSynthEngine.chat_models())}"
+            )
+
+        self.engine_id = engine_id
+        self.url = f"https://api.textsynth.com/v1/engines/{engine_id.value}/chat"
+        self.headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        self.system_prompt = system_prompt
+
+    def chat(self, messages: List[Message]) -> str:
+        request_body: dict[str, str | list[str]] = {
+            "messages": [msg.content for msg in messages]
+        }
+        if self.system_prompt is not None:
+            request_body["system"] = self.system_prompt
+
+        response = requests.post(self.url, headers=self.headers, json=request_body)
+        response.raise_for_status()
+        return response.json()["text"].strip()

--- a/touche_rad/ai/textsynth.py
+++ b/touche_rad/ai/textsynth.py
@@ -20,7 +20,7 @@ class TextSynthEngine(ChatModelEnum):
 
     @classmethod
     def default_model(cls) -> "TextSynthEngine":
-        return cls.LLAMA3_3_70B_INSTRUCT
+        return cls.MISTRAL_7B
 
     @classmethod
     def chat_models(cls) -> List["TextSynthEngine"]:

--- a/touche_rad/streamlit.py
+++ b/touche_rad/streamlit.py
@@ -1,34 +1,28 @@
 import streamlit as st
 
+from touche_rad.ai import ChatClient, Message
+
 
 class Chat:
-    def __init__(self):
+    def __init__(self, chat_client: ChatClient):
+        self.chat_client = chat_client
         if "messages" not in st.session_state:
             st.session_state.messages = []
 
     def _handle_user(self, content):
-        st.session_state.messages.append(
-            {
-                "role": "user",
-                "content": content,
-            }
-        )
+        st.session_state.messages.append(Message(role="user", content=content))
 
-    def _handle_assistant(self, content):
-        st.session_state.messages.append(
-            {
-                "role": "assistant",
-                "content": f'You said "{content}"',
-            }
-        )
+    def _handle_assistant(self):
+        response = self.chat_client.chat(st.session_state.messages)
+        st.session_state.messages.append(Message(role="assistant", content=response))
 
     def _display_messages(self):
         for message in st.session_state.messages:
-            with st.chat_message(message["role"]):
-                st.markdown(message["content"])
+            with st.chat_message(message.role):
+                st.markdown(message.content)
 
     def render(self):
         if content := st.chat_input("Ask me something."):
             self._handle_user(content)
-            self._handle_assistant(content)
+            self._handle_assistant()
         self._display_messages()


### PR DESCRIPTION
The goal of this PR is to make it easy to use TextSynth and OpenAI while also swapping out each client without having to modify business logic in streamlit app. It also will allow us to drop in new chat clients as we move forward, but let me know if this is overkill

- Adds a base chat client class and models enum
- Adds support for TextSynth engines and chat api
- Adds support for OpenAI models and chat api (also exposes the sdk client as a whole

<img width="1512" alt="Screenshot 2025-02-03 at 18 57 13" src="https://github.com/user-attachments/assets/444a9d16-43ea-4078-933b-4bfbefd9e73a" />
